### PR TITLE
Action to disperse funds to LaunchBadge

### DIFF
--- a/KAP/kap-11.md
+++ b/KAP/kap-11.md
@@ -1,0 +1,46 @@
+---
+kap: 11
+title: LaunchBadge distribution
+type: Action
+subproject: KNS
+sponsor: LaunchBadge
+author: Ryan Leckey (@mehcode)
+status: Draft
+created: 2025-07-15
+deadline: 2025-07-19
+---
+
+## Abstract
+
+Issuance of:
+
+- 42,385.22473852ℏ from 0.0.1443164 (DEV) -> 0.0.40834
+- 21,191.43808862ℏ from 0.0.1443163 (TLD for .ℏ, .hh, & .hbar) -> 0.0.40834
+
+## Rationale
+
+LaunchBadge has been the sole developer on KNS. LaunchBadge exercises its right to withdraw funds from the DEV account.
+
+LaunchBadge is the administrator for the .ℏ, .hh, and .hbar TLDs. All funds in the TLD account have been derived from these three TLDs. LaunchBadge exercises its right to withdraw funds from the TLD account.
+
+## Issuance
+
+DEV Budget balance at the time of this proposal is 42,385.22473852ℏ.
+
+42,385.22473852ℏ to be issued to 0.0.40834 from the DEV Budget.
+
+TLD Budget balance at the time of this proposal is 21,191.43808862ℏ.
+
+21,191.43808862ℏ to be issued to 0.0.40834 from the TLD Budget.
+
+## Open Issues
+
+N/A
+
+## References
+
+- [Kabuto Name Service ("KNS")](https://kabuto.sh/)
+
+## Copyright / License
+
+This document is licensed under the Apache License, Version 2.0 -- (<https://www.apache.org/licenses/LICENSE-2.0>)


### PR DESCRIPTION
This KAP dispurses the DEV and TLD funds to LaunchBadge.